### PR TITLE
Wait on frame completely, due to re-used resources

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -806,6 +806,7 @@ impl HelloTriangleApplication {
 
         match future {
             Ok(future) => {
+                future.wait(None).unwrap(); //Wait on frame, since we're re-using resources
                 self.previous_frame_end[image_index] = Some(Box::new(future) as Box<_>);
             }
             Err(vulkano::sync::FlushError::OutOfDate) => {


### PR DESCRIPTION
You must either wait on the frame, or use a currently unused command buffer. It's not unheard of to rebuild new command buffers every frame. (Or so I'm led to believe from online resources)